### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @NilsIvarNes
+/.security/ @NilsIvarNes

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Land
 product: PRODSPEK
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "felles_kartdatabase"
   system: "standardisering"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_prodspek_fkb_bygnanlegg"
-  title: "Security Champion prodspek_fkb_bygnanlegg"
-spec:
-  type: "security_champion"
-  parent: "land_security_champions"
-  members:
-  - "NilsIvarNes"
-  children:
-  - "resource:prodspek_fkb_bygnanlegg"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "prodspek_fkb_bygnanlegg"
-  links:
-  - url: "https://github.com/kartverket/prodspek_fkb_bygnanlegg"
-    title: "prodspek_fkb_bygnanlegg på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_prodspek_fkb_bygnanlegg"
-  dependencyOf:
-  - "component:prodspek_fkb_bygnanlegg"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml